### PR TITLE
Feat/add field hint popover

### DIFF
--- a/src/BoolField.tsx
+++ b/src/BoolField.tsx
@@ -20,10 +20,12 @@
 import * as React from 'react';
 import { Checkbox, CheckboxProps } from '@patternfly/react-core/dist/js/components/Checkbox';
 import { Switch, SwitchProps } from '@patternfly/react-core/dist/js/components/Switch';
-import { connectField, FieldProps } from 'uniforms';
-import wrapField from './wrapField';
-import { FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core/dist/js';
+import { FormHelperText } from '@patternfly/react-core/dist/js/components/Form';
+import { HelperText, HelperTextItem } from '@patternfly/react-core/dist/js/components/HelperText';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import { connectField, FieldProps } from 'uniforms';
+import FieldHintPopover from './FieldHintPopover';
+import wrapField, { WrapFieldProps } from './wrapField';
 
 enum ComponentType {
   checkbox = 'checkbox',
@@ -32,7 +34,7 @@ enum ComponentType {
 
 export type BoolFieldProps = FieldProps<
   boolean,
-  CheckboxProps & SwitchProps,
+  CheckboxProps & SwitchProps & WrapFieldProps,
   {
     appearance?: ComponentType;
     inputRef?: React.RefObject<Switch | Checkbox> & React.RefObject<HTMLInputElement>;
@@ -43,7 +45,7 @@ function BoolField({ appearance, disabled, id, inputRef, label, name, onChange, 
   const Component = appearance === ComponentType.switch ? Switch : Checkbox;
   return wrapField(
     { id, ...props },
-    <>
+    <div style={{ display: 'flex', alignItems: 'center' }}>
       {' '}
       <Component
         data-testid={'bool-field'}
@@ -55,6 +57,7 @@ function BoolField({ appearance, disabled, id, inputRef, label, name, onChange, 
         ref={inputRef}
         label={label}
       />
+      <FieldHintPopover default={props.default} description={props.description} />
       <FormHelperText>
         <HelperText>
           <HelperTextItem icon={props.error === false && <ExclamationCircleIcon />} variant={props.error ? 'error' : 'default'}>
@@ -62,7 +65,7 @@ function BoolField({ appearance, disabled, id, inputRef, label, name, onChange, 
           </HelperTextItem>
         </HelperText>
       </FormHelperText>
-    </>,
+    </div>,
   );
 }
 

--- a/src/DateField.tsx
+++ b/src/DateField.tsx
@@ -21,11 +21,11 @@ import * as React from "react";
 import { useMemo } from "react";
 import { connectField, FieldProps } from "uniforms";
 import { TextInput, TextInputProps } from "@patternfly/react-core/dist/js/components/TextInput";
-import wrapField from "./wrapField";
+import wrapField, { WrapFieldProps } from "./wrapField";
 
 export type DateFieldProps = FieldProps<
   Date,
-  TextInputProps,
+  TextInputProps & WrapFieldProps,
   {
     inputRef?: React.RefObject<HTMLInputElement>;
     labelProps?: object;

--- a/src/FieldHintPopover.tsx
+++ b/src/FieldHintPopover.tsx
@@ -1,0 +1,41 @@
+import { Button, Popover, PopoverProps, Text, TextVariants } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+
+interface FieldHintPopoverProps {
+  default?: any;
+  description?: PopoverProps['bodyContent'];
+}
+
+/**
+ * Returns a label tooltip element for the form or undefined if the field has no description
+ * @returns
+ * @param props
+ */
+const FieldHintPopover: FunctionComponent<FieldHintPopoverProps> = (props) => {
+  if (!props.description) {
+    return null;
+  }
+
+  return (
+    <Popover
+      aria-label="Property description"
+      bodyContent={props.description}
+      data-testid="property-description-popover"
+      footerContent={<Text component={TextVariants.small}>Default: {props.default ?? <i>No default value</i>}</Text>}
+      className="pf-v5-u-my-0"
+    >
+      <Button
+        variant="plain"
+        type="button"
+        aria-label="More info for field"
+        className="field-hint-button"
+        data-testid="field-hint-button"
+      >
+        <HelpIcon />
+      </Button>
+    </Popover>
+  );
+};
+
+export default FieldHintPopover;

--- a/src/NumField.tsx
+++ b/src/NumField.tsx
@@ -21,7 +21,7 @@ import * as React from "react";
 import { Ref } from "react";
 import { TextInput, TextInputProps } from "@patternfly/react-core/dist/js/components/TextInput";
 import { connectField } from "uniforms";
-import wrapField from "./wrapField";
+import wrapField, { WrapFieldProps } from "./wrapField";
 
 export type NumFieldProps = {
   id: string;
@@ -31,7 +31,8 @@ export type NumFieldProps = {
   disabled?: boolean;
   value?: number;
   error?: boolean;
-} & Omit<TextInputProps, "isDisabled">;
+} & Omit<TextInputProps, 'isDisabled'> &
+  WrapFieldProps;
 
 function NumField(props: NumFieldProps) {
   const onChange = (value: string, event: React.FormEvent<HTMLInputElement>) => {

--- a/src/RadioField.tsx
+++ b/src/RadioField.tsx
@@ -21,7 +21,7 @@ import { Radio } from '@patternfly/react-core/dist/js/components/Radio';
 import { Fragment } from 'react';
 import { connectField, filterDOMProps, HTMLFieldProps } from 'uniforms';
 import { TransformFn } from './SelectField.types';
-import wrapField from './wrapField';
+import wrapField, { WrapFieldProps } from './wrapField';
 
 export type RadioFieldProps = HTMLFieldProps<
   string,
@@ -32,11 +32,12 @@ export type RadioFieldProps = HTMLFieldProps<
     onChange: (value: string) => void;
     value?: string;
     disabled?: boolean;
-  }
+  } & WrapFieldProps
 >;
 
 function RadioField(props: RadioFieldProps) {
   filterDOMProps.register('checkboxes', 'decimal');
+
   return wrapField(
     props,
     <div data-testid={'radio-field'} {...filterDOMProps(props)}>

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -23,7 +23,7 @@ import { TextInput, TextInputProps } from '@patternfly/react-core/dist/js/compon
 import * as React from 'react';
 import { Ref, useCallback, useMemo } from 'react';
 import { connectField, filterDOMProps } from 'uniforms';
-import wrapField from './wrapField';
+import wrapField, { WrapFieldProps } from './wrapField';
 
 export type TextFieldProps = {
   id: string;
@@ -36,7 +36,8 @@ export type TextFieldProps = {
   errorMessage?: string;
   helperText?: string;
   field?: { format: string };
-} & Omit<TextInputProps, 'isDisabled'>;
+} & Omit<TextInputProps, 'isDisabled'> &
+  Omit<WrapFieldProps, 'ref'>;
 
 const timeRgx = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(:[0-5][0-9])?/;
 

--- a/src/__tests__/BoolField.test.tsx
+++ b/src/__tests__/BoolField.test.tsx
@@ -90,6 +90,22 @@ test("<BoolField> - renders a input with correct value (specified)", () => {
   expect(screen.getByTestId("bool-field")).toHaveAttribute("checked");
 });
 
+test("<BoolField> - renders an input with correct hint popover description provided", () => {
+  const { getByTestId } = render(
+    usingUniformsContext(<BoolField name="x" description="BoolFieldDescription" />, { x: { type: Boolean } }),
+  );
+
+  expect(getByTestId("field-hint-button")).toBeInTheDocument();
+});
+
+test("<BoolField> - renders an input without hint popover when description not provided", () => {
+  const { queryByTestId } = render(
+    usingUniformsContext(<BoolField name="x" />, { x: { type: Boolean } }),
+  );
+
+  expect(queryByTestId('field-hint-button')).not.toBeInTheDocument();
+});
+
 test("<BoolField> - renders a input which correctly reacts on change", () => {
   const onChange = jest.fn();
 

--- a/src/__tests__/BoolField.test.tsx
+++ b/src/__tests__/BoolField.test.tsx
@@ -27,21 +27,21 @@ test("<BoolField> - renders an input", () => {
   expect(screen.getByTestId("bool-field")).toBeInTheDocument();
 });
 
-test("<BoolField> - renders a input with correct id (inherited)", () => {
+test("<BoolField> - renders an input with correct id (inherited)", () => {
   render(usingUniformsContext(<BoolField name="x" />, { x: { type: Boolean } }));
 
   expect(screen.getByTestId("bool-field")).toBeInTheDocument();
   expect(screen.getByTestId("bool-field").getAttribute("id")).toEqual("uniforms-0000-0001");
 });
 
-test("<BoolField> - renders a input with correct id (specified)", () => {
+test("<BoolField> - renders an input with correct id (specified)", () => {
   render(usingUniformsContext(<BoolField name="x" id="y" />, { x: { type: Boolean } }));
 
   expect(screen.getByTestId("bool-field")).toBeInTheDocument();
   expect(screen.getByTestId("bool-field").getAttribute("id")).toBe("y");
 });
 
-test("<BoolField> - renders a input with correct name", () => {
+test("<BoolField> - renders an input with correct name", () => {
   render(usingUniformsContext(<BoolField name="x" />, { x: { type: Boolean } }));
 
   expect(screen.getByTestId("bool-field")).toBeInTheDocument();
@@ -62,28 +62,28 @@ test("<BoolField> - renders an input with correct disabled state", () => {
   expect(screen.getByTestId("bool-field")).toBeDisabled();
 });
 
-test("<BoolField> - renders a input with correct label (specified)", () => {
+test("<BoolField> - renders an input with correct label (specified)", () => {
   render(usingUniformsContext(<BoolField name="x" label="BoolFieldLabel" />, { x: { type: Boolean } }));
 
   expect(screen.getByTestId("bool-field")).toBeInTheDocument();
   expect(screen.getByText("BoolFieldLabel")).toBeInTheDocument();
 });
 
-test("<BoolField> - renders a input with correct value (default)", () => {
+test("<BoolField> - renders an input with correct value (default)", () => {
   render(usingUniformsContext(<BoolField name="x" />, { x: { type: Boolean } }));
 
   expect(screen.getByTestId("bool-field")).toBeInTheDocument();
   expect(screen.getByTestId("bool-field")).not.toHaveAttribute("checked");
 });
 
-test("<BoolField> - renders a input with correct value (model)", () => {
+test("<BoolField> - renders an input with correct value (model)", () => {
   render(usingUniformsContext(<BoolField name="x" />, { x: { type: Boolean } }, { model: { x: true } }));
 
   expect(screen.getByTestId("bool-field")).toBeInTheDocument();
   expect(screen.getByTestId("bool-field")).toHaveAttribute("checked");
 });
 
-test("<BoolField> - renders a input with correct value (specified)", () => {
+test("<BoolField> - renders an input with correct value (specified)", () => {
   render(usingUniformsContext(<BoolField name="x" value />, { x: { type: Boolean } }));
 
   expect(screen.getByTestId("bool-field")).toBeInTheDocument();

--- a/src/__tests__/DateField.test.tsx
+++ b/src/__tests__/DateField.test.tsx
@@ -69,6 +69,22 @@ test("<DateField> - renders a input with correct label (specified)", () => {
   expect(screen.getByText("*")).toBeInTheDocument();
 });
 
+test("<DateField> - renders an input with correct hint popover description provided", () => {
+  const { getByTestId } = render(
+    usingUniformsContext(<DateField name="x" description="DateFieldDescription" />, { x: { type: Date } }),
+  );
+
+  expect(getByTestId("field-hint-button")).toBeInTheDocument();
+});
+
+test("<DateField> - renders an input with no hint popover when description is not provided", () => {
+  const { queryByTestId } = render(
+    usingUniformsContext(<DateField name="x" />, { x: { type: Date } }),
+  );
+
+  expect(queryByTestId('field-hint-button')).not.toBeInTheDocument();
+});
+
 test("<DateField> - renders a input with correct value (default)", () => {
   render(usingUniformsContext(<DateField name="x" />, { x: { type: Date } }));
 

--- a/src/__tests__/DateField.test.tsx
+++ b/src/__tests__/DateField.test.tsx
@@ -27,20 +27,20 @@ test("<DateField> - renders an input", () => {
   expect(screen.getByTestId("date-field")).toBeInTheDocument();
 });
 
-test("<DateField> - renders a input with correct id (inherited)", () => {
+test("<DateField> - renders an input with correct id (inherited)", () => {
   render(usingUniformsContext(<DateField name="x" />, { x: { type: Date } }));
 
   expect(screen.getByTestId("date-field")).toBeInTheDocument();
 });
 
-test("<DateField> - renders a input with correct id (specified)", () => {
+test("<DateField> - renders an input with correct id (specified)", () => {
   render(usingUniformsContext(<DateField name="x" id="y" />, { x: { type: Date } }));
 
   expect(screen.getByTestId("date-field")).toBeInTheDocument();
   expect(screen.getByTestId("date-field").getAttribute("id")).toBe("y");
 });
 
-test("<DateField> - renders a input with correct name", () => {
+test("<DateField> - renders an input with correct name", () => {
   render(usingUniformsContext(<DateField name="x" />, { x: { type: Date } }));
 
   expect(screen.getByTestId("date-field")).toBeInTheDocument();
@@ -54,14 +54,14 @@ test("<DateField> - renders an input with correct disabled state", () => {
   expect(screen.getByTestId("date-field") as HTMLInputElement).toBeDisabled();
 });
 
-test("<DateField> - renders a input with correct label (specified)", () => {
+test("<DateField> - renders an input with correct label (specified)", () => {
   render(usingUniformsContext(<DateField required={false} name="x" label="DateFieldLabel" />, { x: { type: Date } }));
 
   expect(screen.getByTestId("date-field")).toBeInTheDocument();
   expect(screen.getByText("DateFieldLabel")).toBeInTheDocument();
 });
 
-test("<DateField> - renders a input with correct label (specified)", () => {
+test("<DateField> - renders an input with correct label (specified)", () => {
   render(usingUniformsContext(<DateField required={true} name="x" label="DateFieldLabel" />, { x: { type: Date } }));
 
   expect(screen.getByTestId("date-field")).toBeInTheDocument();
@@ -85,14 +85,14 @@ test("<DateField> - renders an input with no hint popover when description is no
   expect(queryByTestId('field-hint-button')).not.toBeInTheDocument();
 });
 
-test("<DateField> - renders a input with correct value (default)", () => {
+test("<DateField> - renders an input with correct value (default)", () => {
   render(usingUniformsContext(<DateField name="x" />, { x: { type: Date } }));
 
   expect(screen.getByTestId("date-field")).toBeInTheDocument();
   expect((screen.getByTestId("date-field") as HTMLInputElement).value).toBe("");
 });
 
-test("<DateField> - renders a input with correct value (model)", () => {
+test("<DateField> - renders an input with correct value (model)", () => {
   const now = new Date();
   render(usingUniformsContext(<DateField name="x" />, { x: { type: Date } }, { model: { x: now } }));
 
@@ -101,7 +101,7 @@ test("<DateField> - renders a input with correct value (model)", () => {
   expect((screen.getByTestId("date-field") as HTMLInputElement).value).toEqual(`${stringfyDate}`);
 });
 
-test("<DateField> - renders a input which correctly reacts on change", () => {
+test("<DateField> - renders an input which correctly reacts on change", () => {
   const onChange = jest.fn();
 
   const now = "2000-04-04";
@@ -113,7 +113,7 @@ test("<DateField> - renders a input which correctly reacts on change", () => {
   expect(onChange).toHaveBeenLastCalledWith("x", new Date("2000-04-04T10:20:00.000Z"));
 });
 
-test("<DateField> - renders a input which correctly reacts on change (empty value)", () => {
+test("<DateField> - renders an input which correctly reacts on change (empty value)", () => {
   const onChange = jest.fn();
   const dateValue = new Date("2000-04-04");
 
@@ -125,7 +125,7 @@ test("<DateField> - renders a input which correctly reacts on change (empty valu
   expect(onChange).toHaveBeenLastCalledWith("x", undefined);
 });
 
-test("<DateField> - renders a input which correctly reacts on change (empty)", () => {
+test("<DateField> - renders an input which correctly reacts on change (empty)", () => {
   const onChange = jest.fn();
 
   render(usingUniformsContext(<DateField name="x" onChange={onChange} />, { x: { type: Date } }));
@@ -136,7 +136,7 @@ test("<DateField> - renders a input which correctly reacts on change (empty)", (
   expect(onChange).not.toHaveBeenCalled();
 });
 
-test("<DateField> - renders a input which correctly reacts on change (invalid)", () => {
+test("<DateField> - renders an input which correctly reacts on change (invalid)", () => {
   const onChange = jest.fn();
 
   const now = "10:00";
@@ -148,7 +148,7 @@ test("<DateField> - renders a input which correctly reacts on change (invalid)",
   expect(onChange).not.toHaveBeenCalled();
 });
 
-test("<DateField> - renders a input which correctly reacts on change (valid)", () => {
+test("<DateField> - renders an input which correctly reacts on change (valid)", () => {
   const onChange = jest.fn();
 
   const date = "2000-04-04";
@@ -163,7 +163,7 @@ test("<DateField> - renders a input which correctly reacts on change (valid)", (
   expect(onChange).toHaveBeenLastCalledWith("x", new Date(`${date}T${time}:00.000Z`));
 });
 
-test("<DateField> - renders a input which correctly reacts on change (year bigger than 9999)", () => {
+test("<DateField> - renders an input which correctly reacts on change (year bigger than 9999)", () => {
   const onChange = jest.fn();
 
   render(usingUniformsContext(<DateField name="x" />, { x: { type: Date } }, { onChange }));

--- a/src/__tests__/FieldHintPopover.test.tsx
+++ b/src/__tests__/FieldHintPopover.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { screen } from '@testing-library/dom';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import FieldHintPopover from '../FieldHintPopover';
+
+test('<FieldHintPopover> - renders hint icon', async () => {
+  render(<FieldHintPopover description="This is description" />);
+
+  const element = screen.getByTestId('field-hint-button');
+  expect(element).toBeInTheDocument();
+
+  await act(async () => {
+    fireEvent.click(element);
+  });
+
+  await waitFor(() => expect(screen.getByTestId('property-description-popover')).toBeInTheDocument());
+});

--- a/src/__tests__/NumField.test.tsx
+++ b/src/__tests__/NumField.test.tsx
@@ -247,3 +247,19 @@ test("<NumField> - renders a label", () => {
   const id = screen.getByTestId("num-field").getAttribute("id");
   expect(screen.getByTestId("wrapper-field").getElementsByTagName("label")[0].getAttribute("for")).toBe(id);
 });
+
+test("<NumField> - renders an input with correct hint popover description provided", () => {
+  const { getByTestId } = render(
+    usingUniformsContext(<NumField name="x" description="NumFieldDescription" />, { x: { type: Number } }),
+  );
+
+  expect(getByTestId("field-hint-button")).toBeInTheDocument();
+});
+
+test("<NumField> - renders an input with no hint popover when description is not provided", () => {
+  const { queryByTestId } = render(
+    usingUniformsContext(<NumField name="x" />, { x: { type: Number } }),
+  );
+
+  expect(queryByTestId('field-hint-button')).not.toBeInTheDocument();
+});

--- a/src/__tests__/RadioField.test.tsx
+++ b/src/__tests__/RadioField.test.tsx
@@ -91,6 +91,26 @@ test('<RadioField> - renders a set of checkboxes with correct name', () => {
   expect(screen.getByTestId('radio-field').getElementsByTagName('input')[1].getAttribute('name')).toBe('x');
 });
 
+test("<RadioField> - renders an input with correct hint popover description provided", () => {
+  const { getByTestId } = render(
+    usingUniformsContext(<RadioField name="x" options={['a', 'b']} description="NumFieldDescription" />, {
+      x: { type: String, options: ['a', 'b'] },
+    }),
+  );
+
+  expect(getByTestId("field-hint-button")).toBeInTheDocument();
+});
+
+test("<RadioField> - renders an input with no hint popover when description is not provided", () => {
+  const { queryByTestId } = render(
+    usingUniformsContext(<RadioField name="x" options={['a', 'b']} />, {
+      x: { type: String, options: ['a', 'b'] },
+    }),
+  );
+
+  expect(queryByTestId('field-hint-button')).not.toBeInTheDocument();
+});
+
 test('<RadioField> - renders a set of checkboxes with correct options', () => {
   render(
     usingUniformsContext(<RadioField name="x" options={['a', 'b']} />, {

--- a/src/__tests__/RadioField.test.tsx
+++ b/src/__tests__/RadioField.test.tsx
@@ -93,7 +93,7 @@ test('<RadioField> - renders a set of checkboxes with correct name', () => {
 
 test("<RadioField> - renders an input with correct hint popover description provided", () => {
   const { getByTestId } = render(
-    usingUniformsContext(<RadioField name="x" options={['a', 'b']} description="NumFieldDescription" />, {
+    usingUniformsContext(<RadioField name="x" options={['a', 'b']} description="RadioFieldDescription" />, {
       x: { type: String, options: ['a', 'b'] },
     }),
   );

--- a/src/__tests__/TextField.test.tsx
+++ b/src/__tests__/TextField.test.tsx
@@ -140,6 +140,22 @@ test('<TextField> - renders a help', () => {
   expect(screen.getByTestId('wrapper-field').querySelector('.pf-v5-c-form__helper-text')?.textContent).toBe('y');
 });
 
+test("<TextField> - renders an input with correct hint popover description provided", () => {
+  const { getByTestId } = render(
+    usingUniformsContext(<TextField name="x" description="TextFieldDescription" />, { x: { type: String } }),
+  );
+
+  expect(getByTestId("field-hint-button")).toBeInTheDocument();
+});
+
+test("<TextField> - renders an input with no hint popover when description is not provided", () => {
+  const { queryByTestId } = render(
+    usingUniformsContext(<TextField name="x" />, { x: { type: String } }),
+  );
+
+  expect(queryByTestId('field-hint-button')).not.toBeInTheDocument();
+});
+
 test('<TextField> - renders a initial value on date field (type = date)', () => {
   const date = '2000-04-04';
   render(

--- a/src/__tests__/TextField.test.tsx
+++ b/src/__tests__/TextField.test.tsx
@@ -126,7 +126,7 @@ test('<TextField> - renders a label', () => {
   expect(screen.getByText('y')).toBeInTheDocument();
 });
 
-test('<TextField> - renders a label', () => {
+test('<TextField> - renders a label with required indicator', () => {
   render(usingUniformsContext(<TextField required={true} name="x" label="y" />, { x: { type: String } }));
 
   expect(screen.getByText('y')).toBeInTheDocument();
@@ -181,7 +181,7 @@ test('<TextField> - renders a disabled date field (type = date)', () => {
   expect(screen.getByTestId('text-field') as HTMLInputElement).toBeDisabled();
 });
 
-test('<TextField> - renders a input which correctly reacts on change (type = date)', () => {
+test('<TextField> - renders an input which correctly reacts on change (type = date)', () => {
   const onChange = jest.fn();
   const date = '2000-04-04';
 
@@ -201,7 +201,7 @@ test('<TextField> - renders a input which correctly reacts on change (type = dat
   expect(onChange).toHaveBeenLastCalledWith('x', date);
 });
 
-test('<TextField> - renders a input which correctly reacts on change (type = date - empty)', () => {
+test('<TextField> - renders an input which correctly reacts on change (type = date - empty)', () => {
   const onChange = jest.fn();
   const date = '';
 
@@ -246,7 +246,7 @@ test('<TextField> - renders a disabled date field (type = time)', () => {
   expect(screen.getByTestId('text-field')).toBeDisabled();
 });
 
-test('<TextField> - renders a input which correctly reacts on change (type = time)', () => {
+test('<TextField> - renders an input which correctly reacts on change (type = time)', () => {
   const onChange = jest.fn();
   const time = '10:10';
 
@@ -266,7 +266,7 @@ test('<TextField> - renders a input which correctly reacts on change (type = tim
   expect(onChange).toHaveBeenLastCalledWith('x', '10:10:00');
 });
 
-test('<TextField> - renders a input which correctly reacts on change (type = time - empty)', () => {
+test('<TextField> - renders an input which correctly reacts on change (type = time - empty)', () => {
   const onChange = jest.fn();
   const time = '';
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -29,6 +29,7 @@ it("exports everything", () => {
     DateField: expect.any(Function),
     ErrorField: expect.any(Function),
     ErrorsField: expect.any(Function),
+    FieldHintPopover: expect.any(Function),
     HiddenField: expect.any(Function),
     ListAddField: expect.any(Function),
     ListDelField: expect.any(Function),

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export { default as DateField } from "./DateField";
 export { default as ErrorField } from "./ErrorField";
 export { default as ErrorsField } from "./ErrorsField";
 export { default as HiddenField } from "./HiddenField";
+export { default as FieldHintPopover } from "./FieldHintPopover";
 export { default as ListAddField } from "./ListAddField";
 export { default as ListDelField } from "./ListDelField";
 export { default as ListField } from "./ListField";

--- a/src/wrapField.tsx
+++ b/src/wrapField.tsx
@@ -20,6 +20,7 @@
 import { FormGroup, FormGroupProps } from '@patternfly/react-core/dist/js/components/Form';
 import * as React from 'react';
 import { FilterDOMPropsKeys, filterDOMProps } from 'uniforms';
+import FieldHintPopover from './FieldHintPopover';
 
 declare module 'uniforms' {
   interface FilterDOMProps {
@@ -50,26 +51,40 @@ filterDOMProps.register(
   'placeholder' as FilterDOMPropsKeys,
 );
 
-type WrapperProps = {
+export type WrapFieldProps = {
   id: string;
   error?: any;
   errorMessage?: string;
   help?: string;
   showInlineError?: boolean;
+  description?: React.ReactNode;
 } & Omit<FormGroupProps, 'onChange' | 'fieldId'>;
 
 export default function wrapField(
-  { id, label, type, disabled, error, errorMessage, showInlineError, help, required, ...props }: WrapperProps,
+  {
+    id,
+    label,
+    type,
+    disabled,
+    error,
+    errorMessage,
+    showInlineError,
+    help,
+    required,
+    description,
+    ...props
+  }: WrapFieldProps,
   children: React.ReactNode,
 ) {
   return (
     <FormGroup
-      data-testid={'wrapper-field'}
+      data-testid="wrapper-field"
       data-fieldname={props.name}
       fieldId={id}
       label={label}
       isRequired={required}
       type={type}
+      labelIcon={description ? <FieldHintPopover description={description} /> : undefined}
       {...filterDOMProps(props)}
     >
       {children}


### PR DESCRIPTION
Fix: https://github.com/KaotoIO/kaoto-next/issues/685

Hey, I made this PR to abstract the custom `FieldLabelIcon` component (renamed to `FieldHintPopover`)  made in Kaoto-UI repository, to integrate the component directly into the library and also help removing the `labelIcon` warning.

This is a screenshot from Kaoto-UI reflecting the field hint popover using the changes.
![Screenshot_2024-01-22_at_10_32_41](https://github.com/KaotoIO/uniforms-patternfly/assets/17992718/abfa6038-91f7-468e-975f-1c7a45150614)

I also added some tests and fixed some typos.

Feel free to let me know if this is useful and or any changes required.

Thanks! 