### PR TITLE
fix(695): Missing spacing between nested form fields

### DIFF
--- a/src/NestField.scss
+++ b/src/NestField.scss
@@ -1,0 +1,4 @@
+.nestfield-spacing {
+  display: grid;
+  gap: var(--pf-v5-c-form--GridGap);
+}

--- a/src/NestField.tsx
+++ b/src/NestField.tsx
@@ -21,6 +21,7 @@ import * as React from "react";
 import { connectField, filterDOMProps, HTMLFieldProps } from "uniforms";
 import { Card, CardBody } from "@patternfly/react-core/dist/js/components/Card";
 import AutoField from "./AutoField";
+import './NestField.scss';
 
 export type NestFieldProps = HTMLFieldProps<object, HTMLDivElement, { helperText?: string; itemProps?: object }>;
 
@@ -38,7 +39,7 @@ function NestField({
 }: NestFieldProps) {
   return (
     <Card data-testid={"nest-field"} {...filterDOMProps(props)}>
-      <CardBody className="pf-c-form">
+      <CardBody className="pf-c-form nestfield-spacing">
         {label && (
           <label>
             <b>{label}</b>


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto-next/issues/695,

This is how it looks now:
![image](https://github.com/KaotoIO/uniforms-patternfly/assets/73224329/f0789d80-15a6-4e28-9162-88913b53ff9f)
 