### PR TITLE
Add field wrapp to LongTextField to allign with other fields

### DIFF
--- a/src/LongTextField.tsx
+++ b/src/LongTextField.tsx
@@ -17,9 +17,10 @@
  * under the License.
  */
 
-import * as React from "react";
 import { TextArea } from "@patternfly/react-core/dist/js/components/TextArea";
-import { connectField, filterDOMProps, HTMLFieldProps } from "uniforms";
+import * as React from "react";
+import { connectField, HTMLFieldProps } from "uniforms";
+import wrapField from "./wrapField";
 
 export type LongTextFieldProps = HTMLFieldProps<
   string,
@@ -43,20 +44,20 @@ function LongTextField({
   value,
   ...props
 }: LongTextFieldProps) {
-  return (
-    <div data-testid={"long-text-field"} {...filterDOMProps(props)}>
-      {label && <label htmlFor={id}>{label}</label>}
-      <TextArea
-        id={id}
-        disabled={disabled}
-        name={name}
-        aria-label={name}
-        onChange={(event, value) => onChange(event.target.value)}
-        placeholder={placeholder}
-        ref={inputRef}
-        value={value ?? ""}
-      />
-    </div>
+  return wrapField(
+    { id, label, name, value, ...props },
+    <TextArea
+      id={id}
+      disabled={disabled}
+      name={name}
+      data-testid={'long-text-field'}
+      aria-label={name}
+      onChange={(event, value) => onChange(event.target.value)}
+      placeholder={placeholder}
+      ref={inputRef}
+      resizeOrientation="vertical"
+      value={value ?? ""}
+    />
   );
 }
 

--- a/src/__tests__/LongTextField.test.tsx
+++ b/src/__tests__/LongTextField.test.tsx
@@ -31,7 +31,7 @@ test("<LongTextField> - renders a textarea with correct disabled state", () => {
   render(usingUniformsContext(<LongTextField name="x" disabled />, { x: { type: String } }));
 
   expect(screen.getByTestId("long-text-field")).toBeInTheDocument();
-  const textarea = screen.getByTestId("long-text-field").getElementsByTagName("textarea")[0];
+  const textarea = screen.getByTestId("long-text-field");
   expect(textarea).toBeDisabled();
 });
 
@@ -39,7 +39,7 @@ test("<LongTextField> - renders a textarea with correct id (inherited)", () => {
   render(usingUniformsContext(<LongTextField name="x" />, { x: { type: String } }));
 
   expect(screen.getByTestId("long-text-field")).toBeInTheDocument();
-  const textarea = screen.getByTestId("long-text-field").getElementsByTagName("textarea")[0];
+  const textarea = screen.getByTestId("long-text-field");
   expect(textarea.getAttribute("id")).toBeTruthy();
 });
 
@@ -47,7 +47,7 @@ test("<LongTextField> - renders a textarea with correct id (specified)", () => {
   render(usingUniformsContext(<LongTextField name="x" id="y" />, { x: { type: String } }));
 
   expect(screen.getByTestId("long-text-field")).toBeInTheDocument();
-  const textarea = screen.getByTestId("long-text-field").getElementsByTagName("textarea")[0];
+  const textarea = screen.getByTestId("long-text-field");
   expect(textarea.getAttribute("id")).toBe("y");
 });
 
@@ -55,7 +55,7 @@ test("<LongTextField> - renders a textarea with correct name", () => {
   render(usingUniformsContext(<LongTextField name="x" />, { x: { type: String } }));
 
   expect(screen.getByTestId("long-text-field")).toBeInTheDocument();
-  const textarea = screen.getByTestId("long-text-field").getElementsByTagName("textarea")[0];
+  const textarea = screen.getByTestId("long-text-field");
   expect(textarea.getAttribute("name")).toBe("x");
 });
 
@@ -63,7 +63,7 @@ test("<LongTextField> - renders a textarea with correct placeholder", () => {
   render(usingUniformsContext(<LongTextField name="x" placeholder="y" />, { x: { type: String } }));
 
   expect(screen.getByTestId("long-text-field")).toBeInTheDocument();
-  const textarea = screen.getByTestId("long-text-field").getElementsByTagName("textarea")[0];
+  const textarea = screen.getByTestId("long-text-field");
   expect(textarea.getAttribute("placeholder")).toBe("y");
 });
 
@@ -71,7 +71,7 @@ test("<LongTextField> - renders a textarea with correct value (default)", () => 
   render(usingUniformsContext(<LongTextField name="x" />, { x: { type: String } }));
 
   expect(screen.getByTestId("long-text-field")).toBeInTheDocument();
-  const textarea = screen.getByTestId("long-text-field").getElementsByTagName("textarea")[0];
+  const textarea = screen.getByTestId("long-text-field");
   expect(textarea.getAttribute("value")).toBe(null);
 });
 
@@ -95,7 +95,7 @@ test("<LongTextField> - renders a textarea which correctly reacts on change", ()
   render(usingUniformsContext(<LongTextField name="x" />, { x: { type: String } }, { onChange }));
 
   expect(screen.getByTestId("long-text-field")).toBeInTheDocument();
-  const textarea = screen.getByTestId("long-text-field").getElementsByTagName("textarea")[0];
+  const textarea = screen.getByTestId("long-text-field");
   fireEvent.change(textarea, { target: { value: "y" } });
   expect(onChange).toHaveBeenLastCalledWith("x", "y");
 });
@@ -106,7 +106,7 @@ test("<LongTextField> - renders a textarea which correctly reacts on change (emp
   render(usingUniformsContext(<LongTextField name="x" />, { x: { type: String } }, { onChange }));
 
   expect(screen.getByTestId("long-text-field")).toBeInTheDocument();
-  const textarea = screen.getByTestId("long-text-field").getElementsByTagName("textarea")[0];
+  const textarea = screen.getByTestId("long-text-field");
   fireEvent.change(textarea, { target: { value: "" } });
   expect(onChange).not.toHaveBeenCalled();
 });
@@ -117,7 +117,7 @@ test("<LongTextField> - renders a textarea which correctly reacts on change (sam
   render(usingUniformsContext(<LongTextField name="x" />, { x: { type: String } }, { model: { x: "y" }, onChange }));
 
   expect(screen.getByTestId("long-text-field")).toBeInTheDocument();
-  const textarea = screen.getByTestId("long-text-field").getElementsByTagName("textarea")[0];
+  const textarea = screen.getByTestId("long-text-field");
   fireEvent.change(textarea, { target: { value: "y" } });
   expect(screen.getByText("y")).toBeInTheDocument();
   expect(onChange).not.toHaveBeenCalled();


### PR DESCRIPTION
LongTextField had different look of it's label - changed to align with other used fields by using the field wrapper.

related to https://github.com/KaotoIO/kaoto-next/issues/892