### PR TITLE
feat(build): Add `peerDependencies`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,8 +15,3 @@ packageExtensions:
   "uniforms-bridge-simple-schema-2@*":
     dependencies:
       "react": "^18.2.0"
-
-  "@types/testing-library__react@*":
-    peerDependencies:
-      "react": "*"
-      "react-dom": "*"

--- a/package.json
+++ b/package.json
@@ -38,10 +38,15 @@
   },
   "dependencies": {
     "invariant": "^2.2.4",
-    "lodash": "^4.17.21",
+    "lodash.clonedeep": "^4.5.0",
+    "uniforms": "4.0.0-alpha.5"
+  },
+  "peerDependencies": {
+    "@patternfly/react-core": "^5.0.0",
+    "@patternfly/react-icons": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "uniforms": "4.0.0-alpha.5"
+    "uniforms-bridge-simple-schema-2": "^4.0.0-alpha.5"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",
@@ -68,6 +73,8 @@
     "copyfiles": "^2.4.1",
     "jest": "^29.4.2",
     "jest-environment-jsdom": "^29.4.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "rimraf": "^6.0.0",
     "sass": "^1.70.0",
     "simpl-schema": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,7 +2842,7 @@ __metadata:
     invariant: ^2.2.4
     jest: ^29.4.2
     jest-environment-jsdom: ^29.4.2
-    lodash: ^4.17.21
+    lodash.clonedeep: ^4.5.0
     react: ^18.2.0
     react-dom: ^18.2.0
     rimraf: ^6.0.0
@@ -2853,6 +2853,12 @@ __metadata:
     typescript: ^5.0.2
     uniforms: 4.0.0-alpha.5
     uniforms-bridge-simple-schema-2: 4.0.0-alpha.5
+  peerDependencies:
+    "@patternfly/react-core": ^5.0.0
+    "@patternfly/react-icons": ^5.0.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    uniforms-bridge-simple-schema-2: ^4.0.0-alpha.5
   languageName: unknown
   linkType: soft
 
@@ -7750,6 +7756,13 @@ __metadata:
   version: 3.0.0
   resolution: "lodash._reinterpolate@npm:3.0.0"
   checksum: 06d2d5f33169604fa5e9f27b6067ed9fb85d51a84202a656901e5ffb63b426781a601508466f039c720af111b0c685d12f1a5c14ff8df5d5f27e491e562784b2
+  languageName: node
+  linkType: hard
+
+"lodash.clonedeep@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.clonedeep@npm:4.5.0"
+  checksum: 92c46f094b064e876a23c97f57f81fbffd5d760bf2d8a1c61d85db6d1e488c66b0384c943abee4f6af7debf5ad4e4282e74ff83177c9e63d8ff081a4837c3489
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context
Since we need to use this library in different environments, we need to externalize `react*` and `@patternfly/*` dependencies.