### PR TITLE
fix: Disable focus trap in field hint popover

### DIFF
--- a/src/FieldHintPopover.tsx
+++ b/src/FieldHintPopover.tsx
@@ -26,6 +26,7 @@ const FieldHintPopover: FunctionComponent<FieldHintPopoverProps> = (props) => {
       footerContent={<Text component={TextVariants.small}>Default: {props.default ?? <i>No default value</i>}</Text>}
       className="pf-v5-u-my-0"
       triggerAction="hover"
+      withFocusTrap={false}
     >
       <Button
         variant="plain"


### PR DESCRIPTION
fix: https://github.com/KaotoIO/kaoto/issues/1080

**Before**
The following video shows the focus being stolen in an endless loop by the field hint component, as described in: https://github.com/KaotoIO/kaoto/issues/1080.

I can only exit the loop after pressing ESC.

https://github.com/user-attachments/assets/806e1a82-6b8b-484f-8036-3da2f2b6170f

**After**

PatternFly Popover component uses a focus trap which I believe is not needed for the purpose of uniforms, so I disabled it. 

https://github.com/user-attachments/assets/1fcac4d3-b67c-4b6f-8078-8f5f430569e5


