### PR TITLE
fix(Form): Form not being rendered

### DIFF
--- a/src/BaseForm.tsx
+++ b/src/BaseForm.tsx
@@ -28,7 +28,7 @@ function Patternfly(parent: any): any {
     static displayName = `Patternfly${parent.displayName}`;
 
     render() {
-      const { key, props } = this.getNativeFormProps();
+      const { key, ...props } = this.getNativeFormProps();
       return (
         <context.Provider value={this.getContext()}>
           <Form key={key} data-testid="base-form" {...props} />


### PR DESCRIPTION
### Context
After merging #151, the form is no longer rendering because the `props` object is not being restructured correctly (https://github.com/KaotoIO/uniforms-patternfly/pull/151/files#diff-564a460f0cdc5338a887be8300b8a6f76365a4d492a2d0dbe1156fc90853c250R31)

The fix is to use the `...` destructure operator so all the properties are captured in the props object.

This will extract `key` and `props` from the `getNativeFormProps` method
```typescript
const { key, props } = this.getNativeFormProps();
```

Wheres this will extract `key` and the remaining properties will be kept in the `props` object.
```typescript
const { key, ...props } = this.getNativeFormProps();
```